### PR TITLE
[FEAT: BERANDA] : add misi kami sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "clsx": "^2.1.1",
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(next@15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 15.5.3
         version: 15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -933,6 +936,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3221,6 +3228,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/src/components/beranda/BerandaSection.tsx
+++ b/src/components/beranda/BerandaSection.tsx
@@ -1,6 +1,7 @@
 import '@/styles/beranda.css';
 import { FAQSection } from './FAQ/FAQSection';
 import { HeroSection } from './hero/HeroSection';
+import { MisiKamiSection } from './misi-kami/MisiKamiSection';
 import { TentangKamiSection } from './tentang-kami/TentangKamiSection';
 
 const BerandaSection = () => {
@@ -9,7 +10,7 @@ const BerandaSection = () => {
       <HeroSection />
       <TentangKamiSection />
       {/* visi kami section */}
-      {/* misi kami section */}
+      <MisiKamiSection />
       {/* prestasi terbaru section */}
       {/* project terbaru section */}
       {/* apa kata mereka section */}

--- a/src/components/beranda/misi-kami/MisiKamiButton.tsx
+++ b/src/components/beranda/misi-kami/MisiKamiButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import clsx from 'clsx';
+import React from 'react';
+
+interface MisiKamiButtonProps {
+  label: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+export const MisiKamiButton: React.FC<MisiKamiButtonProps> = ({
+  label,
+  active = false,
+  onClick,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'text- w-full rounded-2xl px-4 py-3 text-base font-medium transition-all duration-200',
+        'flex cursor-pointer items-center justify-center font-medium',
+        active
+          ? 'bg-[#FFCB5C]'
+          : 'border-[1.2px] border-[#FFE7B7] bg-[#FFF7ED] hover:bg-[#FFECB1]'
+      )}
+    >
+      {label}
+    </button>
+  );
+};

--- a/src/components/beranda/misi-kami/MisiKamiSection.tsx
+++ b/src/components/beranda/misi-kami/MisiKamiSection.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+import { misiKamiData } from '@/data/beranda/misiKamiData';
+
+import { SectionHeading } from '../SectionHeading';
+
+import { MisiKamiButton } from './MisiKamiButton';
+
+export const MisiKamiSection = () => {
+  const [selectedId, setSelectedId] = useState(1);
+  const selectedItem = misiKamiData.find(item => item.id === selectedId);
+
+  return (
+    <section className="mx-auto">
+      <SectionHeading title="Misi Kami" />
+
+      <div className="mt-6 flex flex-col items-center justify-center gap-8 md:mt-10 md:flex-row md:gap-16 xl:gap-24">
+        <div className="flex w-full flex-col gap-4 md:w-[350px] md:max-w-[350px]">
+          {misiKamiData.map(item => (
+            <MisiKamiButton
+              key={item.id}
+              label={item.title}
+              active={selectedId === item.id}
+              onClick={() => setSelectedId(item.id)}
+            />
+          ))}
+        </div>
+
+        <div
+          className="flex w-full items-center justify-center rounded-[20px] border border-[#FFCB5C] px-6 py-10 text-left sm:px-8 md:h-[260px] md:max-w-[550px] md:p-10"
+          style={{
+            background:
+              'linear-gradient(104deg, #FFF7ED 9.98%, #FFFBF6 28.58%, #FFF7ED 50.19%, #FFFAF4 78.46%, #FFF7ED 97.9%)',
+          }}
+        >
+          <p className="text-base leading-relaxed md:text-lg">
+            {selectedItem?.description}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/data/beranda/misiKami.ts
+++ b/src/data/beranda/misiKami.ts
@@ -1,1 +1,0 @@
-export const misiKami = [];

--- a/src/data/beranda/misiKamiData.ts
+++ b/src/data/beranda/misiKamiData.ts
@@ -1,0 +1,32 @@
+export interface MisiKamiItem {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export const misiKamiData: MisiKamiItem[] = [
+  {
+    id: 1,
+    title: 'Meningkatkan bakat',
+    description:
+      'Mendukung mahasiswa Teknik Informatika untuk mengembangkan kemampuan teknis dan kreativitas melalui kegiatan belajar bersama, proyek komunitas, dan sesi berbagi ilmu antar mahasiswa.',
+  },
+  {
+    id: 2,
+    title: 'Kolaboratif',
+    description:
+      'Membangun lingkungan kolaboratif di mana mahasiswa dapat saling belajar, bekerja sama dalam proyek teknologi, dan menciptakan solusi inovatif secara tim.',
+  },
+  {
+    id: 3,
+    title: 'Semangat kontribusi',
+    description:
+      'Menumbuhkan semangat berbagi pengetahuan dan berkontribusi bagi sesama mahasiswa melalui mentoring, seminar, workshop, dan kegiatan pengembangan komunitas.',
+  },
+  {
+    id: 4,
+    title: 'Persiapan dunia kerja',
+    description:
+      'Membantu mahasiswa mempersiapkan diri menghadapi dunia profesional dengan membangun pengalaman nyata, portofolio proyek, dan soft skill yang relevan dengan industri.',
+  },
+];


### PR DESCRIPTION
Pull request ini menutup issue #15 dengan menambahkan section baru "Misi Kami" pada halaman Beranda (Home), menjadikannya interaktif dan informatif bagi pengguna. Implementasi ini mencakup penambahan komponen baru, data pendukung, serta pembaruan dependensi untuk mendukung styling UI.

**Penambahan Fitur: Section "Misi Kami"**

* Menambahkan komponen `MisiKamiSection` pada halaman Beranda untuk menampilkan item misi dengan fitur interaktif (pilihan dan tampilan deskripsi). (`src/components/beranda/BerandaSection.tsx`, `src/components/beranda/misi-kami/MisiKamiSection.tsx`)
* Membuat komponen `MisiKamiButton` untuk memilih item misi, menggunakan library `clsx` untuk styling bersyarat. (`src/components/beranda/misi-kami/MisiKamiButton.tsx`)

**Data dan Struktur**

* Menambahkan file data `misiKamiData` yang berisi daftar item misi dan deskripsinya untuk digunakan di section baru. (`src/data/beranda/misiKamiData.ts`)
* Menghapus ekspor `misiKami` yang tidak digunakan. (`src/data/beranda/misiKami.ts`)

**Pembaruan Dependensi**

* Menambahkan package `clsx` ke `package.json` dan memperbarui `pnpm-lock.yaml`. Library ini digunakan untuk mengelola dan menggabungkan className secara dinamis pada komponen React dengan cara yang lebih ringkas dan efisien, sehingga memudahkan penerapan kondisi styling. (`package.json`, `pnpm-lock.yaml`)

✅ Seluruh TODO pada issue #15 telah selesai:

* [x] Memastikan sudah menerapkan `Link` dari `next/image`
* [x] Membuat komponen untuk elemen berulang agar dapat di-mapping
* [x] Slicing UI Beranda: Misi Kami Section desktop
* [x] Slicing UI Beranda: Misi Kami Section tablet
* [x] Slicing UI Beranda: Misi Kami Section mobile
* [x] Memastikan kembali agar responsifnya berjalan sesuai keinginan